### PR TITLE
feat: add assertion helper functions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -106,6 +106,46 @@ export function orderLocales(localesToOrder: LooseLocaleCode[]): LocaleCode[] {
 type LooseLocaleCode = LocaleCode | (string & {});
 
 /**
+ * Check if the string is a valid `LocaleCode`
+ * @param locale
+ * @returns true if the locale is a valid `LocaleCode`
+ *
+ * @example
+ *
+ * ```ts
+ *   const locale: string = 'en';
+ *   if (isLocaleCode(locale)) {
+ *     const typedLocale: LocaleCode = locale; // no error
+ *   }
+ *   const typedLocale2: LocaleCode = locale; // error as locale is string
+ * ```
+ */
+export function isLocaleCode(locale: LooseLocaleCode): locale is LocaleCode {
+  return orderedLocaleCodes.includes(locale as LocaleCode);
+}
+
+/**
+ * Use this function to assert that a `string` is a valid `LocaleCode`
+ * @param locale
+ * @throws Error if the locale is not a valid `LocaleCode`
+ *
+ * @example
+ *
+ * ```ts
+ *   const locale: string = 'en';
+ *   assertLocaleCode(locale);
+ *   const typedLocale: LocaleCode = locale; // no error as locale is now LocaleCode typed
+ * ```
+ */
+export function assertLocaleCode(
+  locale: LooseLocaleCode
+): asserts locale is LocaleCode {
+  if (!orderedLocaleCodes.includes(locale as LocaleCode)) {
+    throw new Error(`Invalid Locale Code: ${locale}`);
+  }
+}
+
+/**
  * Function to check if a locale is CJK - Chinese/Japanese/Korean.
  * Often logic is set to be different in these three language types as they
  * use chinese characters or their derivatives


### PR DESCRIPTION
Functions to help with checking if a string is actually a `LocaleCode`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.1.0--canary.8.8ff4c06fa767fe8316230ea08cfb9d7b03a56d86.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/locales@2.1.0--canary.8.8ff4c06fa767fe8316230ea08cfb9d7b03a56d86.0
  # or 
  yarn add @tablecheck/locales@2.1.0--canary.8.8ff4c06fa767fe8316230ea08cfb9d7b03a56d86.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
