### PR TITLE
fix: traditional chinese label

### DIFF
--- a/src/localeDefinitions/chineseTraditional.ts
+++ b/src/localeDefinitions/chineseTraditional.ts
@@ -3,7 +3,7 @@ import { localeTypeCheck } from '../types';
 export const chineseTraditional = {
   code: 'zh-TW',
   facebook: 'zh_TW',
-  label: '繁体中文',
+  label: '繁體中文',
   loadingText: '讀取中・・・',
   aliases: ['zh-MO', 'zh-HK', 'zh-Hant'],
   translations: {


### PR DESCRIPTION
Update label for Traditional Chinese ('繁体中文' -> '繁體中文')

fixes [bexs-4520](https://tablecheck.atlassian.net/browse/BEXS-4520)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.1.1--canary.10.67c1efe6eb11e78092ee17152fc4a4e9dc30c83e.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/locales@2.1.1--canary.10.67c1efe6eb11e78092ee17152fc4a4e9dc30c83e.0
  # or 
  yarn add @tablecheck/locales@2.1.1--canary.10.67c1efe6eb11e78092ee17152fc4a4e9dc30c83e.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
