### PR TITLE
Remove postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,19 +12,14 @@
     "url": "https://github.com/tablecheck/locales/issues"
   },
   "version": "2.4.1",
-  "keywords": [
-    "locales"
-  ],
+  "keywords": ["locales"],
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "vite build && tsc -p tsconfig.build.json",
     "lint": "eslint .",
-    "postinstall": "husky",
     "prepare": "npm run build",
     "test": "vitest"
   },
@@ -48,9 +43,6 @@
   },
   "lint-staged": {
     "**/!(*.ts)": "prettier --ignore-unknown --write",
-    "**/*.ts": [
-      "eslint --fix",
-      "prettier --write"
-    ]
+    "**/*.ts": ["eslint --fix", "prettier --write"]
   }
 }


### PR DESCRIPTION
postinstall script runs after installing as an npm package so this prevents installation where husky is not installed separately

Error when installing latest version in booking-form

![CleanShot 2025-04-01 at 12 31 54](https://github.com/user-attachments/assets/21fc8de6-8fe4-4631-a08f-13711ef37e81)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.4.2--canary.15.14186557497.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/locales@2.4.2--canary.15.14186557497.0
  # or 
  yarn add @tablecheck/locales@2.4.2--canary.15.14186557497.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
