### PR TITLE
Fix build to support older build tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "version": "2.4.1",
   "keywords": ["locales"],
-  "main": "./dist/index.cjs",
+  "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": ["dist"],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,9 +6,24 @@ export default defineConfig(({ command }) => ({
   build: {
     lib: {
       entry: resolve(__dirname, 'src/index.ts'),
-      formats: ['es', 'cjs'],
+      formats: ['es'],
       fileName: (format, entryName) =>
         basename(entryName, 'tsx') + (format === 'es' ? '.js' : '.cjs'),
+    },
+    target: 'es2019',
+    rollupOptions: {
+      output: [
+        {
+          format: 'es',
+          preserveModules: true,
+        },
+      ],
+    },
+  },
+  esbuild: {
+    target: 'es2019',
+    supported: {
+      'nullish-coalescing': false,
     },
   },
   define:


### PR DESCRIPTION
Fix the build to safely support older webpack builds (ie NBF) and the newer vite builds
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.4.2--canary.16.14189503739.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @tablecheck/locales@2.4.2--canary.16.14189503739.0
  # or 
  yarn add @tablecheck/locales@2.4.2--canary.16.14189503739.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
